### PR TITLE
ci: switch to public runners

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,4 +15,4 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["jammy", "noble", "windows-latest", "macos-latest"]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest", "macos-latest"]'


### PR DESCRIPTION
Using public runners to reduce resource contention.

Configuration change: https://github.com/canonical/canonical-repo-automation/pull/285

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
