### PR TITLE
ci: test on Python 3.14 and Ubuntu 26.04 (Resolute)

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,4 +15,7 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "windows-latest", "macos-latest"]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm", "self-hosted-linux-amd64-resolute-large", "windows-latest", "macos-latest"]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04-arm", "self-hosted-linux-amd64-resolute-large"]'
+      slow-test-python-versions: '["3.10", "3.12", "3.14"]'
+      fast-test-python-versions: '["3.10", "3.12", "3.14"]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.14",
 ]
 license = "GPL-3.0"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR adds testing for Python 3.14 and Ubuntu 26.04 (Resolute) to the QA workflow. Resolute testing uses the 'self-hosted-linux-amd64-resolute-large' runner.